### PR TITLE
Remove static disclaimer and preset reset button

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
       <div style="width:36px;height:36px;border-radius:10px;background:#e0f2fe;display:flex;align-items:center;justify-content:center;font-weight:700;color:#0369a1">V</div>
       <div>
         <h1>Вигард — калькулятор наливных грузов</h1>
-        <div class="muted">Груз всегда застрахован. ДОПОГ соблюдаем. <b>Спирт</b>: временно не оформляем к перевозке.</div>
       </div>
     </div>
 
@@ -73,7 +72,6 @@
           <select id="trailerSelect"></select>
         </div>
         <div class="btns" style="align-items:end">
-          <button class="btn" id="resetPreset">Сбросить к пресету</button>
           <button class="btn" id="addTrailer">Добавить прицеп</button>
         </div>
       </div>

--- a/index1.html
+++ b/index1.html
@@ -55,7 +55,6 @@
       <div style="width:36px;height:36px;border-radius:10px;background:#e0f2fe;display:flex;align-items:center;justify-content:center;font-weight:700;color:#0369a1">V</div>
       <div>
         <h1>Вигард — калькулятор наливных грузов</h1>
-        <div class="muted">Груз всегда застрахован. ДОПОГ соблюдаем.</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove the hard-coded insurance/disclaimer line from the main headers so it no longer appears in summaries
- delete the "Сбросить к пресету" tanker configuration button to keep the panel compact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db6ce809e0832388f7fe8e1c302819