### PR TITLE
Hide ADR controls and streamline cargo header

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,18 +93,6 @@ function showToast(message, type='ok'){
 
 let productModalKeyHandler=null;
 
-function ensureCargoStyles(){
-  if(document.getElementById('cargoInlineStyles')) return;
-  const style=document.createElement('style');
-  style.id='cargoInlineStyles';
-  style.textContent=`
-.cargoInline{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.singleCargoRow{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-.singleCargoRow .spacer{flex:1 1 auto;}
-`.trim();
-  document.head.appendChild(style);
-}
-
 function ensureSingleCargoSpacer(){
   const row=document.querySelector('#globalCargoPanel .singleCargoRow');
   if(!row) return;
@@ -121,28 +109,9 @@ function ensureSingleCargoSpacer(){
 }
 
 function setupCargoLayout(){
-  ensureCargoStyles();
   const panel=$('globalCargoPanel');
   if(!panel) return;
   if(!panel.dataset.cargoLayoutApplied){
-    const tankSection=$('tankSection');
-    if(tankSection && panel.parentElement===tankSection){
-      const wrapper=document.createElement('div');
-      wrapper.id='globalCargoWrapper';
-      tankSection.parentElement.insertBefore(wrapper, tankSection);
-      wrapper.appendChild(panel);
-    }
-    const typeBlock=$('cargoType')?.closest('div');
-    const addBlock=$('btnAddProduct')?.closest('div');
-    const adrBlock=$('cargoAdr')?.closest('div');
-    const rhoBlock=$('cargoRho')?.closest('div');
-    const row=typeBlock?.parentElement;
-    if(row && typeBlock && addBlock && adrBlock && rhoBlock){
-      const inline=document.createElement('div');
-      inline.className='cargoInline';
-      inline.append(typeBlock, addBlock, adrBlock, rhoBlock);
-      row.appendChild(inline);
-    }
     panel.dataset.cargoLayoutApplied='1';
   }
   const addBtn=$('btnAddProduct');
@@ -263,7 +232,8 @@ function addCustomProduct(label, rho, adr){
   const list = JSON.parse(localStorage.getItem(LS_KEYS.products)||'[]');
   const existingIndex=list.findIndex(item=>item.key===key);
   if(existingIndex>=0) list.splice(existingIndex,1);
-  list.push({ key, label, rho, adr });
+  const adrValue=(typeof adr==='string' && adr.trim())?adr.trim():'Не знаю';
+  list.push({ key, label, rho, adr: adrValue });
   localStorage.setItem(LS_KEYS.products, JSON.stringify(list));
   return key;
 }
@@ -336,7 +306,7 @@ function buildTankRows(state){
   const single=!!app.singleCargo;
   if(thead){
     if(single) thead.innerHTML='<th>Отсек</th><th>Литры</th><th>Тонны</th><th>м³</th>';
-    else thead.innerHTML='<th>Отсек</th><th>Тип груза</th><th>ADR</th><th>ρ (кг/л)</th><th>Литры</th><th>Тонны</th><th>м³</th>';
+    else thead.innerHTML='<th>Отсек</th><th>Тип груза</th><th>ρ (кг/л)</th><th>Литры</th><th>Тонны</th><th>м³</th>';
   }
   const caps=state.caps||[];
   state.rows.forEach((row,idx)=>{
@@ -358,7 +328,6 @@ function buildTankRows(state){
       tr.innerHTML=`
         <td><span class="pill">#${idx+1}</span><div class="cap">лимит ${capText} л</div></td>
         <td><select class="selType">${densityOptionsHtml(row.typeKey||'diesel')}</select></td>
-        <td><select class="selAdr"><option value="—">—</option><option value="3">3</option><option value="8">8</option></select></td>
         <td><input class="inpRho" type="number" step="0.001" value="${row.rho??0.84}"></td>
         <td><input class="inpL" type="number" step="0.001" value="${liters??0}"></td>
         <td><input class="inpT" type="number" step="0.001" value="${tons??0}"></td>
@@ -368,28 +337,29 @@ function buildTankRows(state){
     if(!single){
       const selType=tr.querySelector('.selType');
       if(selType) selType.value=row.typeKey||'diesel';
-      const selAdr=tr.querySelector('.selAdr');
-      if(selAdr) selAdr.value=row.adr||'—';
     }
   });
 }
 function ensureRowsMatchCaps(state){
   if(!Array.isArray(state.caps)) state.caps=[];
   const need=state.caps.length;
-  while(state.rows.length<need) state.rows.push({typeKey:'diesel', adr:'3', rho:0.84, liters:0, tons:0});
+  while(state.rows.length<need) state.rows.push({typeKey:'diesel', adr:'Не знаю', rho:0.84, liters:0, tons:0});
   while(state.rows.length>need) state.rows.pop();
 }
 function tankerFromPreset(compartments){
   const caps=Array.isArray(compartments)?compartments:[0];
-  return { caps:[...caps], rows: caps.map(()=>({typeKey:'diesel', adr:'3', rho:0.84, liters:0, tons:0})) };
+  return { caps:[...caps], rows: caps.map(()=>({typeKey:'diesel', adr:'Не знаю', rho:0.84, liters:0, tons:0})) };
 }
 function applyGlobalCargoToRows(){
   if(!app.trailerState || app.trailerState.type!=='tanker') return;
   const rows=app.trailerState.rows||[];
+  const products=getAllProducts();
+  const selectedProduct=products.find(p=>p.key===app.singleCargoTypeKey);
   rows.forEach(row=>{
     row.typeKey=app.singleCargoTypeKey||row.typeKey||'diesel';
-    const adrVal=['—','3','8'].includes(app.singleCargoAdr)?app.singleCargoAdr:'—';
-    row.adr=adrVal;
+    const fallbackAdr=String(selectedProduct?.adr||'').trim();
+    const candidate=String(app.singleCargoAdr||'').trim();
+    row.adr=(candidate||fallbackAdr||row.adr||'Не знаю');
     const rhoVal=num(app.singleCargoRho, row.rho||0);
     row.rho=(Number.isFinite(rhoVal) && rhoVal>0)?rhoVal:row.rho||0.84;
   });
@@ -405,7 +375,7 @@ function renderSingleCargoControls(){
     mode.checked=!!app.singleCargo;
     mode.disabled=!hasTanker;
   }
-  const typeSelect=$('cargoType');
+  const typeSelect=$('cargoTypeCommon');
   if(typeSelect){
     typeSelect.innerHTML=products.map(p=>`<option value="${p.key}">${p.label}</option>`).join('');
     if(!products.some(p=>p.key===app.singleCargoTypeKey)) app.singleCargoTypeKey=products[0]?.key||'';
@@ -413,24 +383,18 @@ function renderSingleCargoControls(){
     typeSelect.disabled=!hasTanker;
   }
   const product=products.find(p=>p.key===app.singleCargoTypeKey);
-  if(product && app.singleCargo){
-    const adrCandidate=String(product.adr||'—');
-    if(!['—','3','8'].includes(app.singleCargoAdr)) app.singleCargoAdr=adrCandidate;
-    if(!Number.isFinite(app.singleCargoRho) || app.singleCargoRho<=0) app.singleCargoRho=product.rho;
+  if(product){
+    const adrCandidate=String(product.adr||'').trim();
+    if(!String(app.singleCargoAdr||'').trim()){
+      app.singleCargoAdr=adrCandidate||'Не знаю';
+    }
+    if(!Number.isFinite(app.singleCargoRho) || app.singleCargoRho<=0){
+      app.singleCargoRho=product.rho;
+    }
+  } else if(!String(app.singleCargoAdr||'').trim()){
+    app.singleCargoAdr='Не знаю';
   }
-  const adrSelect=$('cargoAdr');
-  if(adrSelect){
-    const options=[
-      { value:'—', label:'Не знаю' },
-      { value:'3', label:'3' },
-      { value:'8', label:'8' }
-    ];
-    adrSelect.innerHTML=options.map(opt=>`<option value="${opt.value}">${opt.label}</option>`).join('');
-    if(!options.some(opt=>opt.value===app.singleCargoAdr)) app.singleCargoAdr='—';
-    adrSelect.value=app.singleCargoAdr||'—';
-    adrSelect.disabled=!hasTanker;
-  }
-  const rhoInput=$('cargoRho');
+  const rhoInput=$('rhoCommon');
   if(rhoInput){
     if(!rhoInput.matches(':focus')){
       rhoInput.value=(Number.isFinite(app.singleCargoRho) && app.singleCargoRho>0)?String(app.singleCargoRho):'';
@@ -515,7 +479,7 @@ function normalizeLoadedState(raw){
   normalized.singleCargo = raw.singleCargo!==false;
   normalized.singleCargoTypeKey = (typeof raw.singleCargoTypeKey==='string' && raw.singleCargoTypeKey.trim()) ? raw.singleCargoTypeKey : 'diesel';
   const adrCandidate = typeof raw.singleCargoAdr==='string' ? raw.singleCargoAdr.trim() : '';
-  normalized.singleCargoAdr = ['—','3','8'].includes(adrCandidate) ? adrCandidate : '—';
+  normalized.singleCargoAdr = adrCandidate || 'Не знаю';
   const rhoNum = Number(raw.singleCargoRho);
   normalized.singleCargoRho = (Number.isFinite(rhoNum) && rhoNum>0) ? rhoNum : 0.84;
   const massVal = raw.totalMassT;
@@ -660,8 +624,8 @@ function addCompartment(){
   const last=caps[caps.length-1]||10000;
   caps.push(last);
   const base=app.singleCargo
-    ? { typeKey: app.singleCargoTypeKey||'diesel', adr: app.singleCargoAdr||'—', rho: num(app.singleCargoRho,0.84) }
-    : app.trailerState.rows[0] || { typeKey:'diesel', adr:'3', rho:0.84 };
+    ? { typeKey: app.singleCargoTypeKey||'diesel', adr: app.singleCargoAdr||'Не знаю', rho: num(app.singleCargoRho,0.84) }
+    : app.trailerState.rows[0] || { typeKey:'diesel', adr:'Не знаю', rho:0.84 };
   app.trailerState.rows.push({typeKey:base.typeKey, adr:base.adr, rho:base.rho, liters:0, tons:0});
   buildTankRows(app.trailerState);
   recalc();
@@ -788,25 +752,25 @@ function recalc(){
       const tonsInput=tr.querySelector('.inpT');
       const m3Cell=tr.querySelector('.outM3');
       let typeKey=single?(app.singleCargoTypeKey||row.typeKey||'diesel'):(tr.querySelector('.selType')?.value||row.typeKey||'diesel');
-      let adr=single?(app.singleCargoAdr||row.adr||'—'):(tr.querySelector('.selAdr')?.value||row.adr||'—');
+      const dict=products.find(d=>d.key===typeKey);
       let rho=single?num(app.singleCargoRho, row.rho||0.84):num(tr.querySelector('.inpRho')?.value, row.rho||0.84);
-      if(!single){
-        const dict=products.find(d=>d.key===typeKey);
-        if(dict){
-          const rhoInp=tr.querySelector('.inpRho');
-          if(rhoInp && !rhoInp.value){
-            rho=dict.rho;
-            setInputValue(rhoInp, rho, 3);
-          }
-          const adrSel=tr.querySelector('.selAdr');
-          if(adrSel){
-            const isValidAdr=['—','3','8'].includes(adr);
-            if(!isValidAdr){
-              adr=String(dict.adr||'—');
-              adrSel.value=adr;
-            }
-          }
+      if(!single && dict){
+        const rhoInp=tr.querySelector('.inpRho');
+        if(rhoInp && !rhoInp.value){
+          rho=dict.rho;
+          setInputValue(rhoInp, rho, 3);
         }
+      }
+      if(single && dict && (!Number.isFinite(rho) || rho<=0)){
+        rho=dict.rho;
+      }
+      let adrSource=single?String(app.singleCargoAdr||'').trim():String(row.adr||'').trim();
+      if(!adrSource){
+        adrSource=String(dict?.adr||'').trim();
+      }
+      const adr=adrSource||'Не знаю';
+      if(single && Number.isFinite(rho) && rho>0){
+        app.singleCargoRho=rho;
       }
       if(!isFinite(rho) || rho<=0){
         warns.push(`Отсек #${i+1}: укажите плотность (>0)`);
@@ -1017,11 +981,8 @@ function bind(){
         const d = getAllProducts().find(x=>x.key===typeKey);
         if(d){
           const rhoInp = tr.querySelector('.inpRho');
-          const adrSel = tr.querySelector('.selAdr');
-          if(rhoInp && !rhoInp.value) rhoInp.value = d.rho;
-          if(adrSel){
-            const val=adrSel.value;
-            if(!['—','3','8'].includes(val)) adrSel.value=String(d.adr||'—');
+          if(rhoInp){
+            setInputValue(rhoInp, d.rho, 3);
           }
           recalc();
         }
@@ -1094,14 +1055,19 @@ function bind(){
     renderSingleCargoControls();
     recalc();
   });
-  const cargoType=$('cargoType');
+  const cargoType=$('cargoTypeCommon');
   if(cargoType) cargoType.addEventListener('change', e=>{
     app.singleCargoTypeKey=e.target.value;
     app.lastLoadRequest=null;
     const prod=getAllProducts().find(p=>p.key===app.singleCargoTypeKey);
     if(prod){
-      app.singleCargoAdr=String(prod.adr||'—');
+      const adrStr=String(prod.adr||'').trim();
+      app.singleCargoAdr=adrStr||'Не знаю';
       app.singleCargoRho=prod.rho;
+      const rhoInput=$('rhoCommon');
+      if(rhoInput){
+        setInputValue(rhoInput, prod.rho, 3);
+      }
     }
     if(app.singleCargo){
       applyGlobalCargoToRows();
@@ -1110,18 +1076,7 @@ function bind(){
     renderSingleCargoControls();
     recalc();
   });
-  const cargoAdr=$('cargoAdr');
-  if(cargoAdr) cargoAdr.addEventListener('change', e=>{
-    const val=String(e.target.value||'').trim();
-    app.singleCargoAdr=['—','3','8'].includes(val)?val:'—';
-    app.lastLoadRequest=null;
-    if(app.singleCargo){
-      applyGlobalCargoToRows();
-      recalc();
-    }
-    renderSingleCargoControls();
-  });
-  const cargoRho=$('cargoRho');
+  const cargoRho=$('rhoCommon');
   if(cargoRho){
     cargoRho.addEventListener('input', e=>{
       const val=parseFloat(e.target.value);
@@ -1192,8 +1147,6 @@ function openProductModal(){
   if(!modal) return;
   const form=$('mp_form');
   if(form) form.reset();
-  const adr=$('mp_adr');
-  if(adr) adr.value='—';
   if(productModalKeyHandler){
     document.removeEventListener('keydown', productModalKeyHandler);
     productModalKeyHandler=null;
@@ -1227,10 +1180,8 @@ function saveProductFromModal(event){
   const rhoStr=(rhoInput?.value||'').trim();
   const rho=parseFloat(rhoStr);
   if(!Number.isFinite(rho) || rho<=0){ showToast('Плотность должна быть >0 кг/л', 'warn'); rhoInput?.focus(); return; }
-  const adrSelect=$('mp_adr');
-  const adrValue=(adrSelect?.value||'—').trim();
-  if(!['—','3','8'].includes(adrValue)){ showToast('Выберите ADR из списка', 'warn'); adrSelect?.focus(); return; }
   const rhoRounded=Number(rho.toFixed(3));
+  const adrValue='Не знаю';
   const key=addCustomProduct(normalizedName, rhoRounded, adrValue);
   app.singleCargoTypeKey=key;
   app.singleCargoAdr=adrValue;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
     .small{font-size:12px;color:#6b7280}
     .singleCargoRow{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
     .singleCargoRow .singleCargoLabel{display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+    .cargoRow{display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin:6px 0 8px}
+    .cargoRow .cargoField{display:flex;flex-direction:column;gap:4px;min-width:120px}
+    .cargoRow .cargoField label{margin:0}
     .kpi{display:grid;gap:12px;grid-template-columns:1fr 1fr}
     .kpi .box{border:1px solid var(--border);border-radius:12px;padding:12px}
     .kpi .t{color:var(--muted);font-size:12px}
@@ -140,21 +143,15 @@
         <div id="ethanolBanner" class="banner" style="display:none">Перевозка спирта временно приостановлена в ТК «Вигард». Расчёт доступен, но оформление заявки недоступно.</div>
         <div id="tankSection">
           <div id="globalCargoPanel">
-            <div class="row" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:6px 0 8px">
-              <div style="flex:1 1 220px;min-width:200px">
-                <label class="small" style="margin:0 0 4px">Тип груза</label>
-                <select id="cargoType"></select>
+            <div class="cargoRow">
+              <div class="cargoField" style="flex:1 1 220px;min-width:200px">
+                <label class="small" for="cargoTypeCommon">Тип груза</label>
+                <select id="cargoTypeCommon"></select>
               </div>
-              <div>
-                <button class="btn" id="btnAddProduct">+ Добавить груз</button>
-              </div>
-              <div style="flex:0 0 120px">
-                <label class="small" style="margin:0 0 4px">ADR</label>
-                <select id="cargoAdr"><option value="—">—</option><option value="3">3</option><option value="8">8</option></select>
-              </div>
-              <div style="flex:0 0 140px">
-                <label class="small" style="margin:0 0 4px">ρ (кг/л)</label>
-                <input id="cargoRho" type="number" step="0.001" placeholder="1.300">
+              <button class="btn" id="btnAddProduct" title="Добавить груз" aria-label="Добавить груз">+</button>
+              <div class="cargoField" style="flex:0 0 140px">
+                <label class="small" for="rhoCommon">ρ (кг/л)</label>
+                <input id="rhoCommon" type="number" step="0.001" placeholder="1.300">
               </div>
             </div>
 
@@ -253,7 +250,6 @@
       </div>
       <div class="row cols-3">
         <div><label>ρ (кг/л)</label><input id="mp_rho" type="number" step="0.001" min="0" max="2" placeholder="1.300"></div>
-        <div><label>ADR</label><select id="mp_adr"><option value="—" selected>—</option><option value="3">3</option><option value="8">8</option></select></div>
       </div>
       <div class="btns" style="margin-top:10px">
         <button class="btn primary" id="mp_save" type="submit">Сохранить</button>

--- a/index1.html
+++ b/index1.html
@@ -26,6 +26,9 @@
     .btn{border:1px solid var(--border);background:#fff;border-radius:12px;padding:10px 14px;font-size:14px;cursor:pointer}
     .btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
     .small{font-size:12px;color:var(--muted)}
+    .cargoRow{display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin:6px 0 8px}
+    .cargoRow .cargoField{display:flex;flex-direction:column;gap:4px;min-width:120px}
+    .cargoRow .cargoField label{margin:0}
     .kpi{display:grid;gap:12px;grid-template-columns:1fr 1fr}
     .kpi .box{border:1px solid var(--border);border-radius:12px;padding:12px}
     .kpi .t{color:var(--muted);font-size:12px}
@@ -156,18 +159,21 @@
         <h3 style="margin:0 0 8px">Отсеки / позиции</h3>
 
         <div id="tankSection">
+          <div class="cargoRow">
+            <div class="cargoField" style="flex:1 1 220px;min-width:200px">
+              <label class="small" for="cargoTypeCommon">Тип груза</label>
+              <select id="cargoTypeCommon"></select>
+            </div>
+            <button class="btn" id="btnAddProduct" title="Добавить груз" aria-label="Добавить груз">+</button>
+            <div class="cargoField" style="flex:0 0 140px">
+              <label class="small" for="rhoCommon">ρ (кг/л)</label>
+              <input id="rhoCommon" type="number" step="0.001" placeholder="1.300">
+            </div>
+          </div>
           <div class="row inline" style="justify-content:space-between;margin:6px 0 8px">
             <div style="display:flex;gap:12px;align-items:center">
-              <label class="small" style="display:flex;gap:8px;align-items:center"><input id="singleCargoMode" type="checkbox" checked> все отсеки — один груз</label>
+              <label class="small" style="display:flex;gap:8px;align-items:center"><input id="chkAllSame" type="checkbox" checked> все отсеки — один груз</label>
               <button class="btn" id="fillMax">Заполнить по максимуму</button>
-            </div>
-            <div style="display:flex;gap:8px;align-items:center">
-              <div id="singleCargoControls" style="display:flex;gap:8px;align-items:center">
-                <select id="singleCargoType"></select>
-                <span class="small" id="singleCargoAdr">ADR: —</span>
-                <label class="small" style="display:flex;gap:6px;align-items:center">ρ <input id="singleCargoRho" type="number" step="0.001" style="width:90px"></label>
-              </div>
-              <button class="btn" id="btnAddProduct">+ Добавить груз</button>
             </div>
           </div>
 
@@ -264,7 +270,6 @@
     <div class="row cols-3">
       <div><label>Название</label><input id="prod_name" placeholder="Введите"></div>
       <div><label>ρ (кг/л)</label><input id="prod_rho" type="number" step="0.001" placeholder="Введите"></div>
-      <div><label>ADR</label><input id="prod_adr" placeholder="Введите"></div>
     </div>
     <div class="small" style="margin-top:8px">Груз сохранится и сразу появится в списке.</div>
     <div class="btns" style="margin-top:10px">


### PR DESCRIPTION
## Summary
- replace the compartment header with a shared cargo selector, add button, and density input while hiding ADR across the UI
- synchronize the new controls with existing recalculation logic, updating density defaults and custom product handling
- update both modern and legacy pages and scripts to disable ADR UI elements and keep new controls in sync with tank rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db96fd5b7c8323811a19f7af1eac61