### PR TITLE
Revamp cargo distribution controls and calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     .btn{border:1px solid var(--border);background:#fff;border-radius:12px;padding:10px 14px;font-size:14px;cursor:pointer}
     .btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
     .small{font-size:12px;color:#6b7280}
-    .singleCargoRow{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+    .singleCargoRow{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
     .singleCargoRow .singleCargoLabel{display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
     .cargoRow{display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin:6px 0 8px}
     .cargoRow .cargoField{display:flex;flex-direction:column;gap:4px;min-width:160px}
@@ -142,38 +142,26 @@
         <div id="ethanolBanner" class="banner" style="display:none">Перевозка спирта временно приостановлена в ТК «Вигард». Расчёт доступен, но оформление заявки недоступно.</div>
         <div id="tankSection">
           <div id="globalCargoPanel">
-            <div class="cargoRow" id="commonCargoControls">
-              <div class="cargoField" style="flex:1 1 220px;min-width:200px">
-                <label class="small" for="cargoTypeCommon" style="margin:0">Тип груза</label>
-                <select id="cargoTypeCommon"></select>
-              </div>
+            <div class="singleCargoRow" style="margin:6px 0 10px">
+              <label class="small singleCargoLabel" for="cargoType" style="margin:0">Тип груза</label>
+              <select id="cargoType"></select>
               <button class="btn" id="btnAddProduct" type="button" aria-label="Добавить груз" title="Добавить груз">+</button>
-              <div class="cargoField" style="flex:0 0 140px">
-                <label class="small" for="rhoCommon" style="margin:0">ρ (кг/л)</label>
-                <input id="rhoCommon" type="number" step="0.001" placeholder="1.300">
-              </div>
-            </div>
-
-            <div class="row cols-2" style="margin:6px 0 10px">
-              <div>
-                <label>Сколько везём (масса), т</label>
-                <div style="display:flex;gap:8px">
-                  <input id="totalMassT" type="number" placeholder="Введите">
-                  <button class="btn" id="btnDistributeMass" style="white-space:nowrap">Распределить по массе</button>
-                </div>
-              </div>
-              <div>
-                <label>Сколько везём (объём), м³</label>
-                <div style="display:flex;gap:8px">
-                  <input id="totalVolM3" type="number" placeholder="Введите">
-                  <button class="btn" id="btnDistributeM3" style="white-space:nowrap">Распределить по объёму</button>
-                </div>
-              </div>
+              <label class="small singleCargoLabel" for="cargoRho" style="margin:0">ρ (кг/л)</label>
+              <input id="cargoRho" type="number" step="0.001" placeholder="1.300">
             </div>
 
             <div class="singleCargoRow" style="margin:6px 0 10px">
-              <label class="small singleCargoLabel"><input id="chkAllSame" type="checkbox" checked><span>все отсеки — один груз</span></label>
-              <button class="btn" id="fillMax">Заполнить по максимуму</button>
+              <label class="small singleCargoLabel" for="totalMassT" style="margin:0">Сколько везём (масса), т</label>
+              <input id="totalMassT" type="number" placeholder="Введите">
+              <button class="btn" id="btnDistributeMass" type="button">Распределить по массе</button>
+              <label class="small singleCargoLabel" for="totalVolM3" style="margin:0">Сколько везём (объём), м³</label>
+              <input id="totalVolM3" type="number" placeholder="Введите">
+              <button class="btn" id="btnDistributeM3" type="button">Распределить по объёму</button>
+            </div>
+
+            <div class="singleCargoRow" style="margin:6px 0 10px">
+              <label class="small singleCargoLabel" style="margin:0"><input id="chkAllSame" type="checkbox" checked><span>все отсеки — один груз</span></label>
+              <button class="btn" id="fillMax" type="button">Заполнить по максимуму</button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add a compact global cargo management row with product selection, density input, and total mass/volume distribution actions
- refactor tanker distribution logic to support shared-cargo mode, conversions between litres/tons/m³, overflow warnings, and updated summaries/KPI output
- remove ADR handling from state persistence while keeping tanker/platform selections, brief generation, and storage migration working

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dbab526a6083238dd29e776a5d6d2f